### PR TITLE
Misstype README.md fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Current list of programs:
 - termux-gui-view: An image viewer that displays images in a small picture-in-picture window. Use the -h option to view all available options.
 - termux-gui-shell: A utility to send raw protocol messages to and from Termux:GUI, for use in scripts. See the man page for more information.
 - termux-gui-pkg: A graphical frontend for pkg.
-- termux-lockscreen-notes: Write notes even from the lockscreen and save them in a file. The notes are not viewable from the lockscreen when you saved them, to see them you have to unlock your phone and open the file in termux.
+- termux-gui-lockscreen-notes: Write notes even from the lockscreen and save them in a file. The notes are not viewable from the lockscreen when you saved them, to see them you have to unlock your phone and open the file in termux.
 - termux-gui-files: A file explorer you can use to select files, folders and navigate in the terminal.
 
 


### PR DESCRIPTION
I found misstype 'termux-lockscreen-notes' on README.md
so, fixed to termux-gui-lockscreen-notes    👀 

![Screenshot_20220201-161736_Chrome](https://user-images.githubusercontent.com/46598063/151927329-c2640ec0-ea38-41d4-b398-38bc441c7dc6.jpg)

![Screenshot_20220201-161319_Termux](https://user-images.githubusercontent.com/46598063/151926891-13b1997c-783b-42af-ae88-04bfaf50f842.jpg)
